### PR TITLE
fix: move to the first page of cameraroll when private checkbox is

### DIFF
--- a/src/viewer/cmd/viewer/templates/camera_roll.html.tmpl
+++ b/src/viewer/cmd/viewer/templates/camera_roll.html.tmpl
@@ -107,6 +107,7 @@
       privateModeCheckbox.addEventListener('change', function() {
         const currentUrl = new URL(window.location.href);
         // Remove all existing query parameters
+        currentUrl.pathname = '/cameraroll/';
         currentUrl.search = '';
         if (this.checked) {
           currentUrl.searchParams.set('private', 'true');


### PR DESCRIPTION
toggled